### PR TITLE
criacao de novos testes cypress

### DIFF
--- a/cypress/e2e/playground.cy.js
+++ b/cypress/e2e/playground.cy.js
@@ -56,4 +56,29 @@ describe('Cypress Playground', () => {
 
     cy.contains('p', "You've selected the following fruits: apple, banana, cherry").should('be.visible')
   })
+  it('checks both possible radios and asserts if it is "on" or "off"', () => {
+    cy.contains('#on-off', 'ON').should('be.visible')
+    cy.get('#off').check()
+    cy.contains('#on-off', 'OFF').should('be.visible')
+    cy.contains('#on-off', 'ON').should('not.exist')
+    cy.get('#on').check()
+    cy.contains('#on-off', 'ON').should('be.visible')
+    cy.contains('#on-off', 'OFF').should('not.exist')
+  });
+
+  it('Uploads a file and asserts the correct file name appears as a paragraph', () => {
+    cy.get('input[type="file"]').selectFile('./cypress/fixtures/example.json')
+    cy.contains('p', "The following file has been selected for upload: example.json").should('be.visible')
+  });
+
+  it('click a button and triggers a request', () => {
+    cy.intercept('GET', 'https://jsonplaceholder.typicode.com/todos/1').as('gettodo')
+    cy.contains('button', 'Get TODO').click()
+    cy.wait('@gettodo').its('response.statusCode').should('be.equal', 200)
+    cy.get('#intercept > ul > :nth-child(1)').should('be.visible')
+    cy.contains('li', 'TODO ID: 1').should('be.visible')
+    cy.contains('li', 'Title: delectus aut autem').should('be.visible')
+    cy.contains('li', 'Completed: false').should('be.visible')
+    cy.contains('li', 'User ID: 1').should('be.visible')
+  });  
 })


### PR DESCRIPTION
**Descrição:**

Curso Cypress Playground

**Testes adicionados:**

Uploads a file and asserts the correct file name appears as a paragraph
click a button and triggers a request

Obs: O teste 'checks both possible radios and asserts if it is "on" or "off"' foi inserido anteriormente.

**Evidências:**

![Captura de Tela 2025-04-12 às 18 08 09](https://github.com/user-attachments/assets/a6ceacf4-c352-4747-932f-badd1d431c6b)
